### PR TITLE
Exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@ A flux store for easily creating responsive designs in an alt application
 
 ## Why Use a Flux Store?
 
-There are many solutions for cleanly handling responsive designs in React applications. One common paradigm is to wrap a given component in another which is reponsible for handling the behavior. While this at first seems good and the "react way", it quickly leads to a lot of biolerplate code in a single component. Also, depending on the implementation, it is possible that many copies of the responsive container would create many different `resize` handlers.
+There are many solutions for cleanly handling responsive designs in React applications. One common paradigm is to wrap a given component in another which is responsible for handling the behavior. While this at first seems good and the "react way", it quickly leads to a lot of boilerplate code in a single component. Also, depending on the implementation, it is possible that many copies of the responsive container would create many different `resize` handlers.
 
-Using a flux store not only reduces the overall noise in a component, but also garuentees that only a single event listener is waiting for resize.
+Using a flux store not only reduces the overall noise in a component, but also guarantees that only a single event listener is waiting for resize.
 
 
 ## Creating the Store
 
-All you need to do is wrap our store in your alt instance's `createStore` method.
+All you need to do is wrap our class in your alt instance's `createStore` method.
 ```js
 // stores/ResponsiveStore.js
 
@@ -49,6 +49,7 @@ const breakpoints = {
 
 // pass your breakpoints to the store factory
 let ResponsiveStore = create_responsive_store(breakpoints)
+
 // pass the store class to alt's wrapper    
 export default alt.createStore(ResponsiveStoreClass)
 ```
@@ -58,13 +59,14 @@ Now your store is ready to use with custom breakpoints.
 
 ## Responding to Browser Width
 
-The ReponsiveStore provides three attributes to handle responsive behavior (passed in as props to the particular component):
+The `ReponsiveStore` provides three attributes to handle responsive behavior (passed in as props to the particular component):
 
-* `current_media_type` is a string whose value is equal to the largest breakpoint category that the browser satisfies.
-* `browser_less_than` is an object of booleans that describe whether the browser is currently less than a particular breakpoint
-* `browser_greater_than` is an object of booleans that describe whether the browser is currently greater than a particular breakpoint
+* `current_media_type`: (*string*) The **largest** breakpoint category that the browser satisfies.
+* `browser_less_than`: (*object*) Hash of booleans that describe whether the browser is currently less than a particular breakpoint.
+* `browser_greater_than`: (*object*) Hash of booleans that describe whether the browser is currently greater than a particular breakpoint.
 
 For example,
+
 ```js
 // MyComponent.js
 
@@ -88,26 +90,21 @@ class MyComponent extends React.Component {
 
 
     render() {
+        let message = `The viewport's current media type is: ${this.props.current_media_type}.  `
+
         if (this.props.browser_less_than.small) {
-            return (
-              <p>
-                You will only see this on browser width less than the small breakpoint!
-              </p>
-            )
+            message += 'Secret message for viewports smaller than than the "small" breakpoint!'
         } else if (this.props.browser_less_than.medium) {
-            return (
-              <p>
-                You will only see this on screens less than the medium breakpoint!
-              </p>
-            )
+            message += 'Secret message for viewports between the "small" and "medium" breakpoints!'
         } else {
-            return (
-              <p>
-                You will only see this on screens above medium size.
-                The browsers current media_type is {this.props.current_media_type}.
-              </p>
-            )
+            message += 'Message for viewports greater than the "medium" breakpoint.'
         }
+
+        return (
+            <p>
+                {message}
+            </p>
+        )
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A flux store for easily creating responsive designs in an alt application
 
 
-## Why Use a Flux Store?
+## Why Use a Flux Store for Responsive Behavior?
 
 There are many solutions for cleanly handling responsive designs in React applications. One common paradigm is to wrap a given component in another which is responsible for handling the behavior. While this at first seems good and the "react way", it quickly leads to a lot of boilerplate code in a single component. Also, depending on the implementation, it is possible that many copies of the responsive container would create many different `resize` handlers.
 
@@ -12,7 +12,7 @@ Using a flux store not only reduces the overall noise in a component, but also g
 
 ## Creating the Store
 
-All you need to do is wrap our class in your alt instance's `createStore` method.
+All you need to do is wrap the ResponsiveStore in your alt instance's `createStore` method. 
 ```js
 // stores/ResponsiveStore.js
 
@@ -25,12 +25,21 @@ import ResponsiveStore from 'alt-responsive'
 export default alt.createStore(ResponsiveStore)
 ```
 
-Now your store is ready to use.
+Now your store is ready to use. The store's default breakpoints match common device sizes and are accessible by the following names which are used to indentify them in your view: 
+
+```js
+const default_breakpoints = {
+    extra_small: 480,
+    small: 768,
+    medium: 992,
+    large: 1200,
+}
+```
 
 
 ### Using Custom Breakpoints
 
-To use your own custom breakpoints, import our `create_responsive_store` factory, and pass it a hash of custom breakpoints.  The names of these breakpoints will be used to identify them in your views.
+To use custom breakpoints, import the `create_responsive_store` factory, and pass it an object with the new names and values. 
 ```js
 // stores/ResponsiveStore.js
 
@@ -62,8 +71,8 @@ Now your store is ready to use with custom breakpoints.
 The `ReponsiveStore` provides three attributes to handle responsive behavior (passed in as props to the particular component):
 
 * `current_media_type`: (*string*) The **largest** breakpoint category that the browser satisfies.
-* `browser_less_than`: (*object*) Hash of booleans that describe whether the browser is currently less than a particular breakpoint.
-* `browser_greater_than`: (*object*) Hash of booleans that describe whether the browser is currently greater than a particular breakpoint.
+* `browser_less_than`: (*object*) An object of booleans that indicate whether the browser is currently less than a particular breakpoint.
+* `browser_greater_than`: (*object*) An object of booleans that indicate whether the browser is currently greater than a particular breakpoint.
 
 For example,
 

--- a/README.md
+++ b/README.md
@@ -5,28 +5,46 @@ A flux store for easily creating responsive designs in an alt application
 
 ## Why Use a Flux Store?
 
-There are many solutions for cleanly handling responsive designs in React applications. One common paradigm is to wrap a given component in another which is reponsible for handling the behavior. While this at first seems good and the "react way", it quickly leads to a lot of biolerplate code in a single component. Also, depending on the implementation, it is possible that many copies of the responsive container would create many different `resize` handlers. 
+There are many solutions for cleanly handling responsive designs in React applications. One common paradigm is to wrap a given component in another which is reponsible for handling the behavior. While this at first seems good and the "react way", it quickly leads to a lot of biolerplate code in a single component. Also, depending on the implementation, it is possible that many copies of the responsive container would create many different `resize` handlers.
 
 Using a flux store not only reduces the overall noise in a component, but also garuentees that only a single event listener is waiting for resize.
 
 
 ## Creating the Store
 
-First create a store based on custom breakpoints using the provided factory. The names of these breakpoints will be used to identify them at a later time.
+All you need to do is wrap our store in your alt instance's `createStore` method.
 ```js
 // stores/ResponsiveStore.js
 
 // import your singleton alt instance
 import alt from 'my-alt-import'
 // import our factory
-import create_responsive_store from 'alt-responsive'
+import ResponsiveStore from 'alt-responsive'
+
+// pass the store class to alt's wrapper    
+export default alt.createStore(ResponsiveStore)
+```
+
+Now your store is ready to use.
+
+
+### Using Custom Breakpoints
+
+To use your own custom breakpoints, import our `create_responsive_store` factory, and pass it a hash of custom breakpoints.  The names of these breakpoints will be used to identify them in your views.
+```js
+// stores/ResponsiveStore.js
+
+// import your singleton alt instance
+import alt from 'my-alt-import'
+// import our factory
+import {create_responsive_store} from 'alt-responsive'
 
 // define your own breakpoints
 const breakpoints = {
-  small: 320, 
-  medium: 640,
-  big: 960,
-  huge: 1024,
+    small: 320,
+    medium: 640,
+    big: 960,
+    huge: 1024,
 }
 
 // pass your breakpoints to the store factory
@@ -35,7 +53,7 @@ let ResponsiveStore = create_responsive_store(breakpoints)
 export default alt.createStore(ResponsiveStoreClass)
 ```
 
-Now your store is ready to use. 
+Now your store is ready to use with custom breakpoints.
 
 
 ## Responding to Browser Width
@@ -43,8 +61,8 @@ Now your store is ready to use.
 The ReponsiveStore provides three attributes to handle responsive behavior (passed in as props to the particular component):
 
 * `current_media_type` is a string whose value is equal to the largest breakpoint category that the browser satisfies.
-* `browser_less_than` is an object of booleans that describe wether the browser is currently less than a particular breakpoint
-* `browser_greater_than` is an object of booleans that describe wether the browser is currently greater than a particular breakpoint
+* `browser_less_than` is an object of booleans that describe whether the browser is currently less than a particular breakpoint
+* `browser_greater_than` is an object of booleans that describe whether the browser is currently greater than a particular breakpoint
 
 For example,
 ```js
@@ -85,7 +103,7 @@ class MyComponent extends React.Component {
         } else {
             return (
               <p>
-                You will only see this on screens above medium size. 
+                You will only see this on screens above medium size.
                 The browsers current media_type is {this.props.current_media_type}.
               </p>
             )

--- a/src/responsiveStore.js
+++ b/src/responsiveStore.js
@@ -3,10 +3,24 @@ import MediaQuery from 'mediaquery'
 import {transform, keys} from 'lodash'
 
 /**
- * @arg {object} breakpoints - Hash of custom breakpoints.
+ * @arg {object} [options]  - Hash of custom breakpoints.
  * @returns {class} Responsive store class to be passed to `alt.createStore`.
  */
-export default function create_responsive_store_class(breakpoints) {
+export default function create_responsive_store_class(options) {
+    // use `options` as hash of breakpoints
+    let breakpoints = options
+    // if `options` was not provided
+    if (typeof options === 'undefined') {
+        // use default breakpoints
+        breakpoints = {
+            extra_small: 480,
+            small: 768,
+            medium: 992,
+            large: 1200,
+        }
+    }
+    // always add `infinity` breakpoint for upper bound
+    breakpoints.infinity = Infinity
 
     class ResponsiveStore {
         constructor() {

--- a/src/responsiveStore.js
+++ b/src/responsiveStore.js
@@ -6,7 +6,8 @@ import {transform, keys} from 'lodash'
  * @arg {object} [options]  - Hash of custom breakpoints.
  * @returns {class} Responsive store class to be passed to `alt.createStore`.
  */
-export default function create_responsive_store_class(options) {
+// export the factory (but not as default)
+export function create_responsive_store(options) {
     // use `options` as hash of breakpoints
     let breakpoints = options
     // if `options` was not provided
@@ -104,5 +105,10 @@ export default function create_responsive_store_class(options) {
 
     return ResponsiveStore
 }
+
+
+// by default, export the default ResponsiveStore
+export default create_responsive_store()
+
 
 // end of file

--- a/src/responsiveStore.js
+++ b/src/responsiveStore.js
@@ -14,10 +14,8 @@ const default_breakpoints = {
  * @returns {class} Responsive store class to be passed to `alt.createStore`.
  */
 // export the factory (but not as default)
-export function create_responsive_store(breakpoints) {
+export function create_responsive_store(breakpoints = default_breakpoints) {
 
-    // use the default breakpoints if the user did not provide any
-    breakpoints = breakpoints ? breakpoints : default_breakpoints
     // add `infinity` breakpoint for upper bound
     breakpoints.infinity = Infinity
 
@@ -27,7 +25,7 @@ export function create_responsive_store(breakpoints) {
             this.breakpoints = breakpoints
             this.media_queries = MediaQuery.asObject(breakpoints)
 
-            //// set the initial store state
+            // set the initial store state
 
             // the current width of the browser
             const browser_width = window.innerWidth

--- a/src/responsiveStore.js
+++ b/src/responsiveStore.js
@@ -1,26 +1,24 @@
-// third parts imports
 import MediaQuery from 'mediaquery'
 import {transform, keys} from 'lodash'
+
+// the default breakpoints to use for the store
+const default_breakpoints = {
+    extra_small: 480,
+    small: 768,
+    medium: 992,
+    large: 1200,
+}
 
 /**
  * @arg {object} [options]  - Hash of custom breakpoints.
  * @returns {class} Responsive store class to be passed to `alt.createStore`.
  */
 // export the factory (but not as default)
-export function create_responsive_store(options) {
-    // use `options` as hash of breakpoints
-    let breakpoints = options
-    // if `options` was not provided
-    if (typeof options === 'undefined') {
-        // use default breakpoints
-        breakpoints = {
-            extra_small: 480,
-            small: 768,
-            medium: 992,
-            large: 1200,
-        }
-    }
-    // always add `infinity` breakpoint for upper bound
+export function create_responsive_store(breakpoints) {
+
+    // use the default breakpoints if the user did not provide any
+    breakpoints = breakpoints ? breakpoints : default_breakpoints
+    // add `infinity` breakpoint for upper bound
     breakpoints.infinity = Infinity
 
     class ResponsiveStore {
@@ -29,7 +27,7 @@ export function create_responsive_store(options) {
             this.breakpoints = breakpoints
             this.media_queries = MediaQuery.asObject(breakpoints)
 
-            // set the initial store state
+            //// set the initial store state
 
             // the current width of the browser
             const browser_width = window.innerWidth


### PR DESCRIPTION
- `create_responsive_store` now has default breakpoints and always adds the `infinity` upper bound breakpoint
- By default, package exports a `ResponsiveStore` (to be wrapped by `alt.createStore`).  The factory is now available through `import {create_responsive_store} from 'alt-responsive'`
